### PR TITLE
Update entitlements.py

### DIFF
--- a/entitlements.py
+++ b/entitlements.py
@@ -6,7 +6,7 @@ import xmlrpclib
 import getpass
 import datetime
 
-SATELLITE_URL = "http://YOUR.SATELLITE.SERVER/rpc/api"
+SATELLITE_URL = "https://YOUR.SATELLITE.SERVER/rpc/api"
 SATELLITE_LOGIN = "userid"
 SATELLITE_PASSWORD = "password"
 


### PR DESCRIPTION
Utilize HTTPS for secure communications to help prevent MITM attacks.

It appears that after Python 2.7.9, the standard http libraries correctly validate certificates by default.
https://www.python.org/dev/peps/pep-0476/
