### PR TITLE
Update list_satellite_users.py

### DIFF
--- a/list_satellite_users.py
+++ b/list_satellite_users.py
@@ -3,7 +3,7 @@
 import xmlrpclib
 import getpass
 
-SATELLITE_URL = "http://YOUR.SATELLITE.SERVER/rpc/api"
+SATELLITE_URL = "https://YOUR.SATELLITE.SERVER/rpc/api"
 SATELLITE_LOGIN = "username"
 SATELLITE_PASSWORD = "password"
 


### PR DESCRIPTION
Utilize HTTPS for secure communications to help prevent MITM attacks.

It appears that after Python 2.7.9, the standard http libraries correctly validate certificates by default.
https://www.python.org/dev/peps/pep-0476/
