### PR TITLE
Update profile2hostname.py

### DIFF
--- a/profile2hostname.py
+++ b/profile2hostname.py
@@ -4,7 +4,7 @@ import xmlrpclib
 import getpass
 import datetime
 
-SATELLITE_URL = "http://YOUR.SATELLITE.SERVER/rpc/api"
+SATELLITE_URL = "https://YOUR.SATELLITE.SERVER/rpc/api"
 SATELLITE_LOGIN = "username"
 SATELLITE_PASSWORD = "password"
 


### PR DESCRIPTION
Utilize HTTPS for secure communications to help prevent MITM attacks.

It appears that after Python 2.7.9, the standard http libraries correctly validate certificates by default.
https://www.python.org/dev/peps/pep-0476/
