### PR TITLE
Update remove_stale.py

### DIFF
--- a/remove_stale.py
+++ b/remove_stale.py
@@ -5,7 +5,7 @@ import xmlrpclib
 import getpass
 import datetime
 
-SATELLITE_URL = "http://YOUR.SATELLITE.SERVER/rpc/api"
+SATELLITE_URL = "https://YOUR.SATELLITE.SERVER/rpc/api"
 # Uncomment and set values for automated login
 #SATELLITE_LOGIN = "userid"
 #SATELLITE_PASSWORD = "password"


### PR DESCRIPTION
Utilize HTTPS for secure communications to help prevent MITM attacks.

It appears that after Python 2.7.9, the standard http libraries correctly validate certificates by default.
https://www.python.org/dev/peps/pep-0476/
